### PR TITLE
add link to heroku demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ WTraining
 
 [![Build Status](https://travis-ci.org/wolox-training/kb-express-js.svg?branch=master)](https://travis-ci.org/wolox-training/kb-express-js)
 
+## Demo
+
+[Heroku](https://wtraining-wolox.herokuapp.com/)
+
 ## First steps
 
 #### Installing node


### PR DESCRIPTION
## Summary

- Add link to heroku as Demo in README.md

## Known Issues

None

## Trello Card

https://trello.com/c/IjoJpLyl/15-hacer-deploy-con-heroku
